### PR TITLE
fix: Add missing jsons dependency

### DIFF
--- a/function_new_recruit_tournaments/requirements.txt
+++ b/function_new_recruit_tournaments/requirements.txt
@@ -5,3 +5,4 @@ requests
 pytest
 pydantic
 
+jsons


### PR DESCRIPTION
Fixes ModuleNotFoundError: No module named 'jsons' in function_new_recruit_tournaments